### PR TITLE
feat: Opt-in rendering for multiline strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Display};
 pub struct Tree<D: Display> {
     root: D,
     leaves: Vec<Tree<D>>,
+    multiline: bool,
 }
 
 impl<D: Display> Tree<D> {
@@ -13,14 +14,37 @@ impl<D: Display> Tree<D> {
         root: D,
         leaves: Vec<Tree<D>>,
     ) -> Tree<D> {
-        Tree { root, leaves }
+        Tree {
+            root,
+            leaves,
+            multiline: false,
+        }
     }
 
     pub fn root(root: D) -> Tree<D> {
         Tree {
             root,
             leaves: Vec::new(),
+            multiline: false,
         }
+    }
+
+    /// Ensure all lines for `root` are indented
+    pub fn with_multiline(
+        mut self,
+        yes: bool,
+    ) -> Self {
+        self.multiline = yes;
+        self
+    }
+
+    /// Ensure all lines for `root` are indented
+    pub fn set_multiline(
+        &mut self,
+        yes: bool,
+    ) -> &mut Self {
+        self.multiline = yes;
+        self
     }
 
     pub fn push(
@@ -38,18 +62,35 @@ impl<D: Display> Tree<D> {
     ) -> fmt::Result {
         for (i, leaf) in leaves.iter().enumerate() {
             let last = i >= leaves.len() - 1;
-            // print single line
-            for s in &spaces {
-                if *s {
-                    write!(f, "    ")?;
-                } else {
-                    write!(f, "|   ")?;
+            let mut prefix = if last { "└──" } else { "├──" };
+
+            if leaf.multiline {
+                let rest_prefix = if last { "   " } else { "|  " };
+                debug_assert_eq!(prefix.chars().count(), rest_prefix.chars().count());
+
+                let root = leaf.root.to_string();
+                for line in root.lines() {
+                    // print single line
+                    for s in &spaces {
+                        if *s {
+                            write!(f, "    ")?;
+                        } else {
+                            write!(f, "|   ")?;
+                        }
+                    }
+                    writeln!(f, "{} {}", prefix, line)?;
+                    prefix = rest_prefix;
                 }
-            }
-            if last {
-                writeln!(f, "└── {}", leaf.root)?;
             } else {
-                writeln!(f, "├── {}", leaf.root)?;
+                // print single line
+                for s in &spaces {
+                    if *s {
+                        write!(f, "    ")?;
+                    } else {
+                        write!(f, "|   ")?;
+                    }
+                }
+                writeln!(f, "{} {}", prefix, leaf.root)?;
             }
 
             // recurse
@@ -90,6 +131,38 @@ mod tests {
             r#"foo
 └── bar
     └── baz
+"#
+        )
+    }
+
+    #[test]
+    fn render_tree_with_multiple_leaves() {
+        let tree = Tree::new("foo", vec![Tree::root("bar"), Tree::root("baz")]);
+        assert_eq!(
+            format!("{}", tree),
+            r#"foo
+├── bar
+└── baz
+"#
+        )
+    }
+
+    #[test]
+    fn render_tree_with_multiline_leaf() {
+        let tree = Tree::new(
+            "foo",
+            vec![
+                Tree::root("hello\nworld").with_multiline(true),
+                Tree::root("goodbye\nworld").with_multiline(true),
+            ],
+        );
+        assert_eq!(
+            format!("{}", tree),
+            r#"foo
+├── hello
+|   world
+└── goodbye
+    world
 "#
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,25 +3,31 @@ use std::fmt::{self, Display};
 /// a simple recursive type which is able to render its
 /// components in a tree-like format
 #[derive(Debug)]
-pub struct Tree<D: Display>(D, Vec<Tree<D>>);
+pub struct Tree<D: Display> {
+    root: D,
+    leaves: Vec<Tree<D>>,
+}
 
 impl<D: Display> Tree<D> {
     pub fn new(
         root: D,
         leaves: Vec<Tree<D>>,
     ) -> Tree<D> {
-        Tree(root, leaves)
+        Tree { root, leaves }
     }
 
     pub fn root(root: D) -> Tree<D> {
-        Tree(root, Vec::new())
+        Tree {
+            root,
+            leaves: Vec::new(),
+        }
     }
 
     pub fn push(
         &mut self,
         leaf: Tree<D>,
     ) -> &mut Self {
-        self.1.push(leaf);
+        self.leaves.push(leaf);
         self
     }
 
@@ -41,16 +47,16 @@ impl<D: Display> Tree<D> {
                 }
             }
             if last {
-                writeln!(f, "└── {}", leaf.0)?;
+                writeln!(f, "└── {}", leaf.root)?;
             } else {
-                writeln!(f, "├── {}", leaf.0)?;
+                writeln!(f, "├── {}", leaf.root)?;
             }
 
             // recurse
-            if !leaf.1.is_empty() {
+            if !leaf.leaves.is_empty() {
                 let mut clone = spaces.clone();
                 clone.push(last);
-                Self::display_leaves(f, &leaf.1, clone)?;
+                Self::display_leaves(f, &leaf.leaves, clone)?;
             }
         }
         write!(f, "")
@@ -62,8 +68,8 @@ impl<D: Display> Display for Tree<D> {
         &self,
         f: &mut fmt::Formatter,
     ) -> fmt::Result {
-        writeln!(f, "{}", self.0)?;
-        Self::display_leaves(f, &self.1, Vec::new())
+        writeln!(f, "{}", self.root)?;
+        Self::display_leaves(f, &self.leaves, Vec::new())
     }
 }
 


### PR DESCRIPTION
In `assert_cmd`, we render assertion failures with treeline and
frequently have multi-line strings.  This will make it easier to see the
content.

Fixes #4