### PR TITLE
fix: use correct character for vertical line

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ target
 └── debug
     ├── .cargo-lock
     ├── .fingerprint
-    |   └── treeline-21a5bdbd42e0b6da
-    |       ├── dep-example-tree
-    |       ├── dep-lib-treeline
-    |       ├── example-tree
-    |       ├── example-tree.json
-    |       ├── lib-treeline
-    |       └── lib-treeline.json
+    │   └── treeline-21a5bdbd42e0b6da
+    │       ├── dep-example-tree
+    │       ├── dep-lib-treeline
+    │       ├── example-tree
+    │       ├── example-tree.json
+    │       ├── lib-treeline
+    │       └── lib-treeline.json
     ├── build
     ├── deps
-    |   └── libtreeline.rlib
+    │   └── libtreeline.rlib
     ├── examples
-    |   ├── tree
-    |   └── tree.dSYM
-    |       └── Contents
-    |           ├── Info.plist
-    |           └── Resources
-    |               └── DWARF
-    |                   └── tree
+    │   ├── tree
+    │   └── tree.dSYM
+    │       └── Contents
+    │           ├── Info.plist
+    │           └── Resources
+    │               └── DWARF
+    │                   └── tree
     ├── libtreeline.rlib
     └── native
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl<D: Display> Tree<D> {
                 if *s {
                     write!(f, "    ")?;
                 } else {
-                    write!(f, "|   ")?;
+                    write!(f, "│   ")?;
                 }
             }
             if last {


### PR DESCRIPTION
The current character (`|`; U+007C VERTICAL LINE) doesn't connect the line correctly. Let's use the correct character (`│`; U+2502 BOX DRAWINGS LIGHT VERTICAL).

Before:

```
target
└── debug
    ├── .cargo-lock
    ├── .fingerprint
    |   └── treeline-21a5bdbd42e0b6da
    |       ├── dep-example-tree
    |       ├── dep-lib-treeline
    |       ├── example-tree
    |       ├── example-tree.json
    |       ├── lib-treeline
    |       └── lib-treeline.json
    ├── build
    ├── deps
    |   └── libtreeline.rlib
    ├── examples
    |   ├── tree
    |   └── tree.dSYM
    |       └── Contents
    |           ├── Info.plist
    |           └── Resources
    |               └── DWARF
    |                   └── tree
    ├── libtreeline.rlib
    └── native
```

After:

```
target
└── debug
    ├── .cargo-lock
    ├── .fingerprint
    │   └── treeline-21a5bdbd42e0b6da
    │       ├── dep-example-tree
    │       ├── dep-lib-treeline
    │       ├── example-tree
    │       ├── example-tree.json
    │       ├── lib-treeline
    │       └── lib-treeline.json
    ├── build
    ├── deps
    │   └── libtreeline.rlib
    ├── examples
    │   ├── tree
    │   └── tree.dSYM
    │       └── Contents
    │           ├── Info.plist
    │           └── Resources
    │               └── DWARF
    │                   └── tree
    ├── libtreeline.rlib
    └── native
```